### PR TITLE
feat: release new package for bundled openapi yaml file

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,4 @@
-name: Publish d.ts package to npmjs
+name: Release npm packages
 on:
   push:
     branches:
@@ -21,8 +21,8 @@ jobs:
       - run: echo 'NPM install & build...'
       - run: npm ci
       - run: npm run build
-      - run: cp ./openapi/base.package.json ./dist/dts/package.json
       - run: echo "__OAS_VERSION=`/usr/bin/yq e '.info.version' openapi/openapi.yaml`" >> "$GITHUB_ENV"
+      - run: cp ./openapi/base.package.json ./dist/yaml/package.json
       - name: Create package.json for yaml package...
         env:
           __PACKAGE_NAME: '@plugoinc/ocpi-openapi-yaml'
@@ -36,6 +36,7 @@ jobs:
           cat ./package.json | jq --arg MAIN $__MAIN_FILE '.main = $MAIN' > ./package.json.tmp
           mv ./package.json.tmp ./package.json
           cat ./package.json
+      - run: cp ./openapi/base.package.json ./dist/dts/package.json
       - name: Create package.json for dts package...
         env:
           __PACKAGE_NAME: '@plugoinc/ocpi-openapi-dts'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - feature/add-yaml-package # temp
 
 jobs:
   publish-dts:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,20 @@ jobs:
       - run: npm run build
       - run: cp ./openapi/base.package.json ./dist/dts/package.json
       - run: echo "__OAS_VERSION=`/usr/bin/yq e '.info.version' openapi/openapi.yaml`" >> "$GITHUB_ENV"
-      - name: Create package.json
+      - name: Create package.json for yaml package...
+        env:
+          __PACKAGE_NAME: '@plugoinc/ocpi-openapi-yaml'
+          __MAIN_FILE: 'openapi.yaml'
+        working-directory: ./dist/yaml
+        run: |
+          cat ./package.json | jq --arg NAME $__PACKAGE_NAME '.name = $NAME' > ./package.json.tmp
+          mv ./package.json.tmp ./package.json
+          cat ./package.json | jq --arg VERSION $__OAS_VERSION '.version = $VERSION' > ./package.json.tmp
+          mv ./package.json.tmp ./package.json
+          cat ./package.json | jq --arg MAIN $__MAIN_FILE '.main = $MAIN' > ./package.json.tmp
+          mv ./package.json.tmp ./package.json
+          cat ./package.json
+      - name: Create package.json for dts package...
         env:
           __PACKAGE_NAME: '@plugoinc/ocpi-openapi-dts'
           __MAIN_FILE: 'schema.d.ts'
@@ -35,8 +48,13 @@ jobs:
           cat ./package.json | jq --arg MAIN $__MAIN_FILE '.main = $MAIN' > ./package.json.tmp
           mv ./package.json.tmp ./package.json
           cat ./package.json
-      - run: echo 'Publish to npmjs...'
-      - run: npm publish -access public
+      - name: Publish yaml package to npmjs...
+        run: npm publish -access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        working-directory: ./dist/yaml
+      - name: Publish dts package to npmjs...
+        run: npm publish -access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         working-directory: ./dist/dts

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - feature/add-yaml-package # temp
 
 jobs:
   publish-dts:

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   "scripts": {
     "start": "openapi preview-docs",
     "build": "npm run clean && npm run build:yaml && npm run build:dts",
-    "build:yaml": "openapi bundle -o dist/yaml/dist.yaml",
-    "build:dts": "openapi-typescript dist/yaml/dist.yaml -o dist/dts/schema.d.ts",
+    "build:yaml": "openapi bundle -o dist/yaml/openapi.yaml",
+    "build:dts": "openapi-typescript dist/yaml/openapi.yaml -o dist/dts/schema.d.ts",
     "clean": "rm -rf dist || true",
     "test": "openapi lint"
   },


### PR DESCRIPTION
Publish new package which contains bundled openapi yaml file.

package name: `@plugoinc/ocpi-openapi-yaml`

Some openapi tools (suck as [openapi-sampler](https://github.com/Redocly/openapi-sampler)) need yaml (or json) file, in that case this package will be helpful.